### PR TITLE
genre fix

### DIFF
--- a/imdb.class.php
+++ b/imdb.class.php
@@ -804,8 +804,9 @@ class IMDB {
             $arrReturned = $this->matchRegex($this->_strSource, IMDB::IMDB_GENRE);
             if (count($arrReturned[1])) {
                 foreach ($arrReturned[1] as $strName) {
-                    if($strName)
+                    if($strName) {
                         $arrReturn[] = trim($strName);
+                    }
                 }
                 return implode($this->strSeperator, array_unique($arrReturn));
             }
@@ -823,8 +824,9 @@ class IMDB {
             $arrReturned = $this->matchRegex($this->_strSource, IMDB::IMDB_GENRE);
             if (count($arrReturned[1])) {
                 foreach ($arrReturned[1] as $i => $strName) {
-                    if($strName)
+                    if($strName) {
                         $arrReturn[] = '<a href="http://www.imdb.com/genre/' . trim($strName) . '/"' . ($strTarget ? ' target="' . $strTarget . '"' : '') . '>' . trim($strName) . '</a>';
+                    }
                 }
                 return implode($this->strSeperator, array_unique($arrReturn));
             }


### PR DESCRIPTION
Fix for genre being empty sometimes, in which case it returns the genres with
an extra separator.
To see what I mean try this in the example script:
$oIMDB = new IMDB('x-men: first class');
